### PR TITLE
Tagless Final

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,7 +78,8 @@ dependencies {
   compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion"
   compile "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
   compile "com.squareup.picasso:picasso:2.5.2"
-  compile 'io.kategory:kategory:0.3.3'
+  //compile 'io.kategory:kategory:0.3.3'
+  compile 'com.github.kategory:kategory:master-SNAPSHOT'
   compile 'com.karumi:marvelapiclient:1.0.1'
 
   testCompile "io.kotlintest:kotlintest:$kotlinTestVersion"

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/KotlinArchitectureApp.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/KotlinArchitectureApp.kt
@@ -6,7 +6,6 @@ import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
 import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
 import com.github.jorgecastillo.kotlinandroid.functional.MonadControl
 import kategory.GlobalInstances
-import kategory.Id
 import kategory.InstanceParametrizedType
 
 class KotlinArchitectureApp : Application() {
@@ -17,11 +16,10 @@ class KotlinArchitectureApp : Application() {
     }
 
     private fun initGlobalInstances() {
-        val id = Id(1)
         GlobalInstances.putIfAbsent(
                 InstanceParametrizedType(
                         MonadControl::class.java,
-                        listOf(AsyncResult.F::class.java, GetHeroesContext::class.java)
+                        listOf(AsyncResult.F::class.java, GetHeroesContext::class.java, CharacterError::class.java)
                 ),
                 AsyncResult
         )

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/KotlinArchitectureApp.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/KotlinArchitectureApp.kt
@@ -1,16 +1,29 @@
 package com.github.jorgecastillo.kotlinandroid
 
 import android.app.Application
+import com.github.jorgecastillo.architecturecomponentssample.model.error.CharacterError
+import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
+import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
+import com.github.jorgecastillo.kotlinandroid.functional.MonadControl
+import kategory.GlobalInstances
 import kategory.Id
+import kategory.InstanceParametrizedType
 
 class KotlinArchitectureApp : Application() {
 
-  override fun onCreate() {
-    super.onCreate()
-    initGlobalInstances()
-  }
+    override fun onCreate() {
+        super.onCreate()
+        initGlobalInstances()
+    }
 
-  private fun initGlobalInstances() {
-    val id = Id(1)
-  }
+    private fun initGlobalInstances() {
+        val id = Id(1)
+        GlobalInstances.putIfAbsent(
+                InstanceParametrizedType(
+                        MonadControl::class.java,
+                        listOf(AsyncResult.F::class.java, GetHeroesContext::class.java)
+                ),
+                AsyncResult
+        )
+    }
 }

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/data/HeroesRepository.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/data/HeroesRepository.kt
@@ -2,7 +2,11 @@ package com.github.jorgecastillo.kotlinandroid.data
 
 import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchAllHeroes
 import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchHeroesFromAvengerComics
+import com.karumi.marvelapiclient.model.CharacterDto
+import kategory.HK
 
-fun getHeroesWithCachePolicy() = fetchAllHeroes()
+inline fun <reified F> getHeroesWithCachePolicy(): HK<F, List<CharacterDto>> =
+        fetchAllHeroes()
 
-fun getHeroesFromAvengerComicsWithCachePolicy() = fetchHeroesFromAvengerComics()
+inline fun <reified F> getHeroesFromAvengerComicsWithCachePolicy(): HK<F, List<CharacterDto>> =
+        fetchHeroesFromAvengerComics()

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
@@ -1,15 +1,16 @@
 package com.github.jorgecastillo.kotlinandroid.data.datasource.remote
 
+import com.github.jorgecastillo.architecturecomponentssample.model.error.CharacterError
 import com.github.jorgecastillo.architecturecomponentssample.model.error.CharacterError.*
 import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
-import com.github.jorgecastillo.kotlinandroid.functional.Future
+import com.github.jorgecastillo.kotlinandroid.functional.*
 import com.karumi.marvelapiclient.MarvelApiException
 import com.karumi.marvelapiclient.MarvelAuthApiException
 import com.karumi.marvelapiclient.model.CharacterDto
 import com.karumi.marvelapiclient.model.CharactersQuery
 import kategory.Either.Left
 import kategory.Either.Right
-import kategory.Reader
+import kategory.*
 import java.net.HttpURLConnection
 
 /*
@@ -24,35 +25,31 @@ import java.net.HttpURLConnection
  * word in the title. Yep, I wanted to retrieve Avengers but the Marvel API is a bit weird
  * sometimes.
  */
-
-fun fetchAllHeroes() = Reader.ask<GetHeroesContext>().map { ctx ->
-  Future {
-    try {
-      val query = CharactersQuery.Builder.create().withOffset(0).withLimit(50).build()
-      Right<List<CharacterDto>>(ctx.apiClient.getAll(query).response.characters)
-    } catch (e: MarvelAuthApiException) {
-      Left(AuthenticationError())
-    } catch (e: MarvelApiException) {
-      if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) {
-        Left(NotFoundError())
-      } else {
-        Left(UnknownServerError())
-      }
-    }
-  }
-}
-
-fun fetchHeroesFromAvengerComics() = fetchAllHeroes().map { future ->
-  future.map {
-    when (it) {
-      is Right -> it.map {
-        it.filter {
-          it.comics.items.map { it.name }.filter {
-            it.contains("Avenger", true)
-          }.count() > 0
+fun exceptionAsCharacterError(e: Throwable): CharacterError =
+        when (e) {
+            is MarvelAuthApiException -> AuthenticationError
+            is MarvelApiException ->
+                if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) NotFoundError
+                else UnknownServerError(Option.Some(e))
+            else -> UnknownServerError((Option.Some(e)))
         }
-      }
-      is Left -> it
-    }
-  }
-}
+
+
+inline fun <reified F> fetchAllHeroes(C : Control<F> = control()): HK<F, List<CharacterDto>> =
+        C.binding {
+            val query = CharactersQuery.Builder.create().withOffset(0).withLimit(50).build()
+            val ctx = !C.ask()
+            C.catch(
+                    { ctx.apiClient.getAll(query).response.characters },
+                    { exceptionAsCharacterError(it) }
+            )
+        }
+
+inline fun <reified F> fetchHeroesFromAvengerComics(C : Control<F> = control()): HK<F, List<CharacterDto>> =
+    C.map(fetchAllHeroes(), {
+            it.filter {
+                it.comics.items.map { it.name }.filter {
+                    it.contains("Avenger", true)
+                }.count() > 0
+            }
+    })

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/SubHeroesDataSource.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/SubHeroesDataSource.kt
@@ -5,7 +5,7 @@ import com.github.jorgecastillo.kotlinandroid.domain.model.SuperHero
 
 class StubHeroesDataSource : HeroesDataSource {
 
-  override fun getAll() = listOf(SuperHero("IronMan"), SuperHero("Spider-Man"),
+  override fun getAll() = listOf(SuperHero("LambdaMan"), SuperHero("AlfredoLambda"), SuperHero("IronMan"), SuperHero("Spider-Man"),
       SuperHero("Batman"), SuperHero("Goku"), SuperHero("Vegeta"), SuperHero("SuperMan"),
       SuperHero("Ant-Man"), SuperHero("Krilin"), SuperHero("Super Mario"), SuperHero("Wolverine"),
       SuperHero("Massacre"), SuperHero("Jake Wharton"), SuperHero("Jesus Christ"),

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/model/CharacterError.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/model/CharacterError.kt
@@ -1,5 +1,7 @@
 package com.github.jorgecastillo.architecturecomponentssample.model.error
 
+import kategory.*
+
 /**
  * This sealed class represents all the possible errors that the app is going to model inside its
  * domain. All the exceptions / errors provoked by third party libraries or APIs are mapped to any
@@ -13,7 +15,7 @@ package com.github.jorgecastillo.architecturecomponentssample.model.error
  * bring not required complexity to the architecture introducing asynchronous semantics.
  */
 sealed class CharacterError {
-  class AuthenticationError : CharacterError()
-  class NotFoundError : CharacterError()
-  class UnknownServerError : CharacterError()
+  object AuthenticationError : CharacterError()
+  object NotFoundError : CharacterError()
+  data class UnknownServerError(val e: Option<Throwable> = Option.None) : CharacterError()
 }

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/UseCases.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/UseCases.kt
@@ -2,7 +2,11 @@ package com.github.jorgecastillo.kotlinandroid.domain.usecase
 
 import com.github.jorgecastillo.kotlinandroid.data.getHeroesFromAvengerComicsWithCachePolicy
 import com.github.jorgecastillo.kotlinandroid.data.getHeroesWithCachePolicy
+import com.karumi.marvelapiclient.model.CharacterDto
+import kategory.HK
 
-fun getHeroesUseCase() = getHeroesWithCachePolicy()
+inline fun <reified F> getHeroesUseCase(): HK<F, List<CharacterDto>> =
+        getHeroesWithCachePolicy()
 
-fun getHeroesFromAvengerComicsUseCase() = getHeroesFromAvengerComicsWithCachePolicy()
+inline fun <reified F> getHeroesFromAvengerComicsUseCase(): HK<F, List<CharacterDto>> =
+        getHeroesFromAvengerComicsWithCachePolicy()

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/Future.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/Future.kt
@@ -1,35 +1,68 @@
 package com.github.jorgecastillo.kotlinandroid.functional
 
+import kategory.*
 import kotlinx.coroutines.experimental.CommonPool
 import kotlinx.coroutines.experimental.Deferred
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.async
 import kotlinx.coroutines.experimental.launch
 
+typealias FutureKind<A> = HK<Future.F, A>
+
+fun <A> FutureKind<A>.ev(): Future<A> =
+        this as Future<A>
+
 /**
  * Basic future implementation to achieve asynchronicity based on Kotlin coroutines.
  */
-class Future<T> {
+class Future<T> : FutureKind<T> {
 
-  private val deferred: Deferred<T>
+    class F private constructor()
 
-  private constructor(deferred: Deferred<T>) {
-    this.deferred = deferred
-  }
+    private val deferred: Deferred<T>
 
-  constructor(f: () -> T) : this(async(CommonPool) { f() })
-
-  fun <X> map(f: (T) -> X): Future<X> {
-    return Future(async(CommonPool) { f(deferred.await()) })
-  }
-
-  fun <X> flatMap(f: (T) -> Future<X>): Future<X> {
-    return Future(async(CommonPool) { f(deferred.await()).deferred.await() })
-  }
-
-  fun onComplete(f: (T) -> Unit) {
-    launch(UI) {
-      f(deferred.await())
+    private constructor(deferred: Deferred<T>) {
+        this.deferred = deferred
     }
-  }
+
+    constructor(f: () -> T) : this(async(CommonPool) { f() })
+
+    fun <X> map(f: (T) -> X): Future<X> {
+        return Future(async(CommonPool) { f(deferred.await()) })
+    }
+
+    fun <X> flatMap(f: (T) -> Future<X>): Future<X> {
+        return Future(async(CommonPool) { f(deferred.await()).deferred.await() })
+    }
+
+    fun <B> zip(fb: Future<B>): Future<Tuple2<T, B>> =
+            flatMap { a -> fb.map { b -> Tuple2(a, b) } }
+
+    fun onComplete(f: (T) -> Unit) {
+        launch(UI) {
+            f(deferred.await())
+        }
+    }
+
+    companion object : Monad<F> {
+        override fun <A, B> flatMap(fa: FutureKind<A>, f: (A) -> FutureKind<B>): Future<B> =
+                fa.ev().flatMap { f(it).ev() }
+
+        override fun <A, B> map(fa: FutureKind<A>, f: (A) -> B): HK<F, B> =
+                fa.ev().map { f(it) }
+
+        override fun <A, B> tailRecM(a: A, f: (A) -> FutureKind<Either<A, B>>): Future<B> =
+                flatMap(f(a).ev()) {
+                    when (it) {
+                        is Either.Left -> tailRecM(a, f)
+                        is Either.Right -> pure(it.b)
+                    }
+                }
+
+        override fun <A> pure(a: A): Future<A> =
+                Future({ a })
+
+        override fun <A, B> product(fa: FutureKind<A>, fb: FutureKind<B>): Future<Tuple2<A, B>> =
+                fa.ev().zip(fb.ev())
+    }
 }

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
@@ -4,82 +4,72 @@ import com.github.jorgecastillo.architecturecomponentssample.model.error.*
 import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
 import kategory.*
 
-typealias Result<A> = Kleisli<AsyncResult.F, GetHeroesContext, A>
+typealias Control<F> = MonadControl<F, GetHeroesContext, CharacterError>
+
+inline fun <reified F> control(): Control<F> = monadControl()
+
 typealias AsyncResultKind<A> = HK<AsyncResult.F, A>
 
 fun <A> AsyncResultKind<A>.ev(): AsyncResult<A> =
         this as AsyncResult<A>
 
+typealias Result<A> = Kleisli<EitherTF<Future.F, CharacterError>, GetHeroesContext, A>
+
 //There should be a monad error instance for EitherT in kategory
-class AsyncResult<A>(val value: EitherT<Future.F, CharacterError, A>) : AsyncResultKind<A> {
-
+class AsyncResult<A>(val value: Result<A>) : AsyncResultKind<A> {
     class F private constructor()
-
-    fun <B> flatMap(f: (A) -> AsyncResultKind<B>): AsyncResult<B> =
-            AsyncResult(ETM.flatMap(value, f.andThen({ it.ev().value })))
-
-    fun <B> map(f: (A) -> B): AsyncResult<B> =
-            AsyncResult(ETM.map(value, f))
-
-    fun <B> product(fb: AsyncResult<B>): AsyncResult<Tuple2<A, B>> =
-            AsyncResult(ETM.product(value, fb.ev().value).ev())
-
-    fun handleErrorWith(f: (CharacterError) -> AsyncResult<A>): AsyncResult<A> {
-        return AsyncResult(EitherT(Future, Future.flatMap(value.value.ev(), {
-            it.fold({ f(it).value.value.ev() }, { Future.pure(Either.Right(it)) })
-        })))
+    companion object :
+            AsyncResultMonadControl,
+            GlobalInstance<MonadControl<AsyncResult.F, GetHeroesContext, CharacterError>>() {
+        fun init() : AsyncResult<Unit> = pure(Unit)
     }
 
-    companion object : MonadError<AsyncResult.F, CharacterError> {
-
-        val ETM = EitherTMonad<Future.F, CharacterError>(Future)
-
-        override fun <A, B> flatMap(fa: AsyncResultKind<A>, f: (A) -> AsyncResultKind<B>): AsyncResult<B> =
-                fa.ev().flatMap(f)
-
-        override fun <A, B> map(fa: AsyncResultKind<A>, f: (A) -> B): HK<F, B> =
-                fa.ev().map(f)
-
-        override fun <A, B> product(fa: AsyncResultKind<A>, fb: AsyncResultKind<B>): AsyncResult<Tuple2<A, B>> =
-                fa.ev().product(fb.ev())
-
-        override fun <A> handleErrorWith(fa: AsyncResultKind<A>, f: (CharacterError) -> AsyncResultKind<A>): AsyncResult<A> =
-                fa.ev().handleErrorWith(f.andThen({ it.ev() }))
-
-        override fun <A, B> tailRecM(a: A, f: (A) -> AsyncResultKind<Either<A, B>>): AsyncResult<B> =
-                AsyncResult(ETM.tailRecM(a, f.andThen({ it.ev().value })))
-
-        override fun <A> raiseError(e: CharacterError): AsyncResult<A> =
-                AsyncResult(EitherT.left(e, Future))
-
-        override fun <A> pure(a: A): AsyncResult<A> =
-                AsyncResult(ETM.pure(a))
-    }
+    fun run(ctx : GetHeroesContext): HK<EitherTF<Future.F, CharacterError>, A> = value.run(ctx)
 }
-typealias KleisliF<F, D> = HK2<Kleisli.F, F, D>
 
-class KleisliMonadError<F, D, E>(val FM: MonadError<F, E>) : MonadError<KleisliF<F, D>, E> {
-    override fun <A, B> flatMap(fa: HK<KleisliF<F, D>, A>, f: (A) -> HK<KleisliF<F, D>, B>): Kleisli<F, D, B> =
-            fa.ev().flatMap(f.andThen { it.ev() })
+interface MonadControl<F, D, E> :
+        MonadError<F, E>,
+        MonadReader<F, D>,
+        Typeclass
 
-    override fun <A, B> map(fa: HK<KleisliF<F, D>, A>, f: (A) -> B): Kleisli<F, D, B> =
-            fa.ev().map(f)
+inline fun <reified F, reified D, reified E> monadControl(): MonadControl<F, D, E> =
+        instance(InstanceParametrizedType(MonadControl::class.java, listOf(F::class.java, D::class.java)))
 
-    override fun <A, B> product(fa: HK<KleisliF<F, D>, A>, fb: HK<KleisliF<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
-            Kleisli(FM, { FM.product(fa.ev().run(it), fb.ev().run(it)) })
+interface AsyncResultMonadControl : MonadControl<AsyncResult.F, GetHeroesContext, CharacterError> {
 
-    override fun <A> handleErrorWith(fa: HK<KleisliF<F, D>, A>, f: (E) -> HK<KleisliF<F, D>, A>): Kleisli<F, D, A> =
-            Kleisli(FM, {
-                FM.handleErrorWith(fa.ev().run(it), { e: E -> f(e).ev().run(it) })
-            })
+    fun ETM(): EitherTMonadError<Future.F, CharacterError> =
+            EitherTInstances(Future)
 
-    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliF<F, D>, Either<A, B>>): Kleisli<F, D, B> =
-            Kleisli(FM, { b -> FM.tailRecM(a, { f(it).ev().run(b) }) })
+    fun KM(): KleisliInstances<EitherTF<Future.F, CharacterError>, GetHeroesContext, CharacterError> =
+            KleisliInstances(ETM())
 
-    override fun <A> raiseError(e: E): Kleisli<F, D, A> =
-            Kleisli(FM, { FM.raiseError(e) })
+    override fun <A, B> map(fa: HK<AsyncResult.F, A>, f: (A) -> B): AsyncResult<B> =
+            AsyncResult(KM().map(fa.ev().value, f))
 
-    override fun <A> pure(a: A): Kleisli<F, D, A> =
-            Kleisli(FM, { FM.pure(a) })
+    override fun <A, B> product(fa: HK<AsyncResult.F, A>, fb: HK<AsyncResult.F, B>): AsyncResult<Tuple2<A, B>> =
+            AsyncResult(KM().product(fa.ev().value, fb.ev().value))
+
+    override fun <A, B> flatMap(fa: HK<AsyncResult.F, A>, f: (A) -> HK<AsyncResult.F, B>): AsyncResult<B> =
+            AsyncResult(KM().flatMap(fa.ev().value, f.andThen { it.ev().value }))
+
+    override fun <A> handleErrorWith(fa: HK<AsyncResult.F, A>, f: (CharacterError) -> HK<AsyncResult.F, A>): AsyncResult<A> =
+            AsyncResult(KM().handleErrorWith(fa.ev().value, f.andThen { it.ev().value }))
+
+    override fun <A, B> tailRecM(a: A, f: (A) -> HK<AsyncResult.F, Either<A, B>>): AsyncResult<B> =
+            AsyncResult(KM().tailRecM(a, f.andThen { it.ev().value }))
+
+    override fun <A> raiseError(e: CharacterError): AsyncResult<A> =
+            AsyncResult(KM().raiseError<A>(e))
+
+    override fun <A> pure(a: A): AsyncResult<A> =
+            AsyncResult(KM().pure(a))
+
+    override fun ask(): AsyncResult<GetHeroesContext> =
+            AsyncResult(KM().ask())
+
+    override fun <A> local(f: (GetHeroesContext) -> GetHeroesContext, fa: HK<AsyncResult.F, A>): AsyncResult<A> =
+            AsyncResult(KM().local(f, fa.ev().value))
 }
+
+
 

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
@@ -56,30 +56,4 @@ class AsyncResult<A>(val value: EitherT<Future.F, CharacterError, A>) : AsyncRes
                 AsyncResult(ETM.pure(a))
     }
 }
-typealias KleisliF<F, D> = HK2<Kleisli.F, F, D>
-
-class KleisliMonadError<F, D, E>(val FM: MonadError<F, E>) : MonadError<KleisliF<F, D>, E> {
-    override fun <A, B> flatMap(fa: HK<KleisliF<F, D>, A>, f: (A) -> HK<KleisliF<F, D>, B>): Kleisli<F, D, B> =
-            fa.ev().flatMap(f.andThen { it.ev() })
-
-    override fun <A, B> map(fa: HK<KleisliF<F, D>, A>, f: (A) -> B): Kleisli<F, D, B> =
-            fa.ev().map(f)
-
-    override fun <A, B> product(fa: HK<KleisliF<F, D>, A>, fb: HK<KleisliF<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
-            Kleisli(FM, { FM.product(fa.ev().run(it), fb.ev().run(it)) })
-
-    override fun <A> handleErrorWith(fa: HK<KleisliF<F, D>, A>, f: (E) -> HK<KleisliF<F, D>, A>): Kleisli<F, D, A> =
-            Kleisli(FM, {
-                FM.handleErrorWith(fa.ev().run(it), { e: E -> f(e).ev().run(it) })
-            })
-
-    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliF<F, D>, Either<A, B>>): Kleisli<F, D, B> =
-            Kleisli(FM, { b -> FM.tailRecM(a, { f(it).ev().run(b) }) })
-
-    override fun <A> raiseError(e: E): Kleisli<F, D, A> =
-            Kleisli(FM, { FM.raiseError(e) })
-
-    override fun <A> pure(a: A): Kleisli<F, D, A> =
-            Kleisli(FM, { FM.pure(a) })
-}
 

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
@@ -1,0 +1,59 @@
+package com.github.jorgecastillo.kotlinandroid.functional
+
+import com.github.jorgecastillo.architecturecomponentssample.model.error.*
+import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
+import kategory.*
+
+typealias Result<A> = Kleisli<AsyncResult.F, GetHeroesContext, A>
+typealias AsyncResultKind<A> = HK<AsyncResult.F, A>
+
+fun <A> AsyncResultKind<A>.ev(): AsyncResult<A> =
+        this as AsyncResult<A>
+
+//There should be a monad error instance for EitherT in kategory
+class AsyncResult<A>(val value: EitherT<Future.F, CharacterError, A>) : AsyncResultKind<A> {
+
+    class F private constructor()
+
+    fun <B> flatMap(f: (A) -> AsyncResultKind<B>): AsyncResult<B> =
+            AsyncResult(ETM.flatMap(value, f.andThen({ it.ev().value })))
+
+    fun <B> map(f: (A) -> B): AsyncResult<B> =
+            AsyncResult(ETM.map(value, f))
+
+    fun <B> product(fb: AsyncResult<B>): AsyncResult<Tuple2<A, B>> =
+            AsyncResult(ETM.product(value, fb.ev().value).ev())
+
+    fun handleErrorWith(f: (CharacterError) -> AsyncResult<A>): AsyncResult<A> {
+        return AsyncResult(EitherT(Future, Future.flatMap(value.value.ev(), {
+            it.fold({ f(it).value.value.ev() }, { Future.pure(Either.Right(it)) })
+        })))
+    }
+
+    companion object : MonadError<AsyncResult.F, CharacterError> {
+
+        val ETM = EitherTMonad<Future.F, CharacterError>(Future)
+
+        override fun <A, B> flatMap(fa: AsyncResultKind<A>, f: (A) -> AsyncResultKind<B>): AsyncResult<B> =
+                fa.ev().flatMap(f)
+
+        override fun <A, B> map(fa: AsyncResultKind<A>, f: (A) -> B): HK<F, B> =
+                fa.ev().map(f)
+
+        override fun <A, B> product(fa: AsyncResultKind<A>, fb: AsyncResultKind<B>): AsyncResult<Tuple2<A, B>> =
+                fa.ev().product(fb.ev())
+
+        override fun <A> handleErrorWith(fa: AsyncResultKind<A>, f: (CharacterError) -> AsyncResultKind<A>): AsyncResult<A> =
+                fa.ev().handleErrorWith(f.andThen({ it.ev() }))
+
+        override fun <A, B> tailRecM(a: A, f: (A) -> AsyncResultKind<Either<A, B>>): AsyncResult<B> =
+                AsyncResult(ETM.tailRecM(a, f.andThen({ it.ev().value })))
+
+        override fun <A> raiseError(e: CharacterError): AsyncResult<A> =
+                AsyncResult(EitherT.left(e, Future))
+
+        override fun <A> pure(a: A): AsyncResult<A> =
+                AsyncResult(ETM.pure(a))
+    }
+}
+

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
@@ -20,9 +20,7 @@ class AsyncResult<A>(val value: Result<A>) : AsyncResultKind<A> {
     class F private constructor()
     companion object :
             AsyncResultMonadControl,
-            GlobalInstance<MonadControl<AsyncResult.F, GetHeroesContext, CharacterError>>() {
-        fun init() : AsyncResult<Unit> = pure(Unit)
-    }
+            GlobalInstance<MonadControl<AsyncResult.F, GetHeroesContext, CharacterError>>()
 
     fun run(ctx : GetHeroesContext): HK<EitherTF<Future.F, CharacterError>, A> = value.run(ctx)
 }
@@ -33,7 +31,7 @@ interface MonadControl<F, D, E> :
         Typeclass
 
 inline fun <reified F, reified D, reified E> monadControl(): MonadControl<F, D, E> =
-        instance(InstanceParametrizedType(MonadControl::class.java, listOf(F::class.java, D::class.java)))
+        instance(InstanceParametrizedType(MonadControl::class.java, listOf(F::class.java, D::class.java, E::class.java)))
 
 interface AsyncResultMonadControl : MonadControl<AsyncResult.F, GetHeroesContext, CharacterError> {
 

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
@@ -56,4 +56,30 @@ class AsyncResult<A>(val value: EitherT<Future.F, CharacterError, A>) : AsyncRes
                 AsyncResult(ETM.pure(a))
     }
 }
+typealias KleisliF<F, D> = HK2<Kleisli.F, F, D>
+
+class KleisliMonadError<F, D, E>(val FM: MonadError<F, E>) : MonadError<KleisliF<F, D>, E> {
+    override fun <A, B> flatMap(fa: HK<KleisliF<F, D>, A>, f: (A) -> HK<KleisliF<F, D>, B>): Kleisli<F, D, B> =
+            fa.ev().flatMap(f.andThen { it.ev() })
+
+    override fun <A, B> map(fa: HK<KleisliF<F, D>, A>, f: (A) -> B): Kleisli<F, D, B> =
+            fa.ev().map(f)
+
+    override fun <A, B> product(fa: HK<KleisliF<F, D>, A>, fb: HK<KleisliF<F, D>, B>): Kleisli<F, D, Tuple2<A, B>> =
+            Kleisli(FM, { FM.product(fa.ev().run(it), fb.ev().run(it)) })
+
+    override fun <A> handleErrorWith(fa: HK<KleisliF<F, D>, A>, f: (E) -> HK<KleisliF<F, D>, A>): Kleisli<F, D, A> =
+            Kleisli(FM, {
+                FM.handleErrorWith(fa.ev().run(it), { e: E -> f(e).ev().run(it) })
+            })
+
+    override fun <A, B> tailRecM(a: A, f: (A) -> HK<KleisliF<F, D>, Either<A, B>>): Kleisli<F, D, B> =
+            Kleisli(FM, { b -> FM.tailRecM(a, { f(it).ev().run(b) }) })
+
+    override fun <A> raiseError(e: E): Kleisli<F, D, A> =
+            Kleisli(FM, { FM.raiseError(e) })
+
+    override fun <A> pure(a: A): Kleisli<F, D, A> =
+            Kleisli(FM, { FM.pure(a) })
+}
 

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
@@ -1,11 +1,15 @@
 package com.github.jorgecastillo.kotlinandroid.presentation
 
+import com.github.jorgecastillo.architecturecomponentssample.model.error.CharacterError
 import com.github.jorgecastillo.architecturecomponentssample.model.error.CharacterError.*
 import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
 import com.github.jorgecastillo.kotlinandroid.domain.usecase.getHeroesUseCase
+import com.github.jorgecastillo.kotlinandroid.functional.Control
+import com.github.jorgecastillo.kotlinandroid.functional.monadControl
 import com.github.jorgecastillo.kotlinandroid.view.viewmodel.SuperHeroViewModel
 import com.karumi.marvelapiclient.model.MarvelImage
-import kategory.Reader
+import kategory.HK
+import kategory.binding
 
 interface SuperHeroesView {
 
@@ -18,24 +22,23 @@ interface SuperHeroesView {
   fun showAuthenticationError()
 }
 
-fun getSuperHeroes() = Reader.ask<GetHeroesContext>().flatMap { (view) ->
-  getHeroesUseCase().map { future ->
-    future.onComplete { res ->
-      res.fold({
-        error ->
-        when (error) {
-          is NotFoundError -> view.showHeroesNotFoundError()
-          is UnknownServerError -> view.showGenericError()
-          is AuthenticationError -> view.showAuthenticationError()
-        }
-      }, {
-        success ->
-        view.drawHeroes(success.map {
-          SuperHeroViewModel(
-              it.name,
-              it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY))
-        })
-      })
-    }
+fun displayErrors(ctx: GetHeroesContext, c: CharacterError) : Unit {
+  when (c) {
+    is NotFoundError -> ctx.view.showHeroesNotFoundError()
+    is UnknownServerError -> ctx.view.showGenericError()
+    is AuthenticationError -> ctx.view.showAuthenticationError()
   }
 }
+
+inline fun <reified F> getSuperHeroes(C: Control<F> = monadControl()): HK<F, Unit> =
+  C.binding {
+    val ctx = !C.ask()
+    val result = !C.handleError(getHeroesUseCase(), { displayErrors(ctx, it); emptyList()})
+    ctx.view.drawHeroes(result.map {
+      SuperHeroViewModel(
+              it.name,
+              it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY))
+    })
+    C.pure(Unit)
+  }
+

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroListActivity.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroListActivity.kt
@@ -6,10 +6,14 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import com.github.jorgecastillo.kotlinandroid.R
 import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
+import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
+import com.github.jorgecastillo.kotlinandroid.functional.ev
+import com.github.jorgecastillo.kotlinandroid.functional.monadControl
 import com.github.jorgecastillo.kotlinandroid.presentation.SuperHeroesView
 import com.github.jorgecastillo.kotlinandroid.presentation.getSuperHeroes
 import com.github.jorgecastillo.kotlinandroid.view.adapter.HeroesCardAdapter
 import com.github.jorgecastillo.kotlinandroid.view.viewmodel.SuperHeroViewModel
+import kategory.binding
 import kotlinx.android.synthetic.main.activity_main.*
 
 class SuperHeroListActivity : AppCompatActivity(), SuperHeroesView {
@@ -31,7 +35,7 @@ class SuperHeroListActivity : AppCompatActivity(), SuperHeroesView {
 
   override fun onResume() {
     super.onResume()
-    getSuperHeroes().run(GetHeroesContext(this))
+    getSuperHeroes(AsyncResult).ev().run(GetHeroesContext(this))
   }
 
   override fun drawHeroes(heroes: List<SuperHeroViewModel>) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,6 @@
 org.gradle.jvmargs=-Xmx1536m
 kotlin.coroutines=enable
 kotlin.incremental=true
+marvelPublicKey="212822db30afe0ebc6a83e2343c42708"
+marvelPrivateKey="4d4bf92832c0df97e684663f402db591253212a9"
+android.enableAapt2=false

--- a/gradlew
+++ b/gradlew
@@ -6,6 +6,9 @@
 ##
 ##############################################################################
 
+LC_NUMERIC="en_US.UTF-8"
+android.enableAapt2=false
+
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
 DEFAULT_JVM_OPTS=""
 


### PR DESCRIPTION
The following PR introduces a Tagless Final style replacing nested Reader and Future datatypes with proper typeclasses.

What this effectively means is that our code is no longer couple to any given data type or runtime semantics but only to behaviors as expressed by the `MonadReader` and `MonadError` typeclasses.

A new Typeclass has been created called `MonadControl` with `Control` as alias and it aggregates the behaviors from `MonadReader` and `MonadError`.

The runtime is provided at the edge of the application by supplying an Instance that implements the behaviors specified by `MonadControl`
```kotlin
getSuperHeroes(AsyncResult).ev().run(GetHeroesContext(this))
```

This effectively mean that you can interpret your entire program to a different runtime perhaps that does not use Future or any of the runtime semantics in production.

Note that all return types are now of `HK<F, A>` where `A` is the result but `F` is a Higher Kind that remains polymorphic until made concrete at the edge of the application.

Addtionally `AsyncResult` holds a value including all the application concerns whereas before this refactoring the DI concerns where separated steps from the async or error handling concerns.

`AsyncResult` holds a value a of type `Result<A>` which is an alias for:
```kotlin
typealias Result<A> = Kleisli<EitherTF<Future.F, CharacterError>, GetHeroesContext, A>
```

Here we can observe that we are providing, dependency injection where `GetHeroesContext` is the dependency, Error handling where `CharacterError` is the know possible errors in the app, Future because we want it to be async and reactive on flatMap chains and finally an EitherT transformer to allow us to bind to `A` when using monadic comprehensions via `Control#binding`

**More details on tagless vs playing with concrete types, by Raúl:**

You have like 2 use styles. One would be to use datatypes diretly, in example:
```kotlin
fun do(): Option<Int> = Option(1).map { it + 1 } // would return an Option(2)
```
The other one would be a completely abstract style. In example:
```kotlin
inline fun <reified F> do(AP: Applicative<F> = applicative()): HK<F, Int> = 
                AP.map(AP.pure(1), { it + 1 })
```
The difference between both styles is that the first one is clearly constraining the implementation to 
 the concrete data types, but with the second one, you could do things like:
```kotlin
do<Option.F>().ev() // Option(1)
do<Try.F>().ev() // Try(1)
```
Or any other data type with an `Applicative` instance existent for it.

That's allowing devs to create applications where they just define their business logic based on behaviors and not on the concrete types being used at runtime. For example, you could create a program that could be run in an asynchronous way in one place and syncrhonously in other places.

Or, if you create a library  you could make your method values to not specify concrete return types to let users choose the behavior that better fits their requirements for their concrete cases.

For this PR, `AsyncResult` is a data type supporting async but the program is written without knowing that. The detail is provided later in the flow, in a final point where we choose which runtime to use (so we pass the `AsyncResult` concrection to it).

The first style is called `monomorfic` since there is not parametrization on top of the type constructors, meanwhile the second one is an abstract style using typeclasses and it's called `polymorphic`, `mtl` or `tagless final`, and it's about just using `typeclasses` instead of concrete types.

`Typeclasses` like `Applicative`, `Monad`, `Functor`, `Traversable`, they have all the APIs you need to create programs of any kind.