### PR TITLE
Concrete AsyncResult monad transformer

### DIFF
--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/KotlinArchitectureApp.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/KotlinArchitectureApp.kt
@@ -1,28 +1,11 @@
 package com.github.jorgecastillo.kotlinandroid
 
 import android.app.Application
-import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
-import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
-import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
-import com.github.jorgecastillo.kotlinandroid.functional.MonadControl
-import kategory.GlobalInstances
-import kategory.InstanceParametrizedType
 
 class KotlinArchitectureApp : Application() {
 
   override fun onCreate() {
     super.onCreate()
-    initGlobalInstances()
   }
 
-  private fun initGlobalInstances() {
-    GlobalInstances.putIfAbsent(
-        InstanceParametrizedType(
-            MonadControl::class.java,
-            listOf(AsyncResult.F::class.java, GetHeroesContext::class.java,
-                CharacterError::class.java)
-        ),
-        AsyncResult
-    )
-  }
 }

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/data/HeroesRepository.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/data/HeroesRepository.kt
@@ -2,11 +2,11 @@ package com.github.jorgecastillo.kotlinandroid.data
 
 import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchAllHeroes
 import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchHeroesFromAvengerComics
+import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
 import com.karumi.marvelapiclient.model.CharacterDto
-import kategory.HK
 
-inline fun <reified F> getHeroesWithCachePolicy(): HK<F, List<CharacterDto>> =
+fun getHeroesWithCachePolicy(): AsyncResult<List<CharacterDto>> =
     fetchAllHeroes()
 
-inline fun <reified F> getHeroesFromAvengerComicsWithCachePolicy(): HK<F, List<CharacterDto>> =
+fun getHeroesFromAvengerComicsWithCachePolicy(): AsyncResult<List<CharacterDto>> =
     fetchHeroesFromAvengerComics()

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
@@ -23,30 +23,30 @@ import java.net.HttpURLConnection
  * sometimes.
  */
 fun exceptionAsCharacterError(e: Throwable): CharacterError =
-    when (e) {
-      is MarvelAuthApiException -> AuthenticationError
-      is MarvelApiException ->
-        if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) NotFoundError
-        else UnknownServerError(Option.Some(e))
-      else -> UnknownServerError((Option.Some(e)))
-    }
+        when (e) {
+            is MarvelAuthApiException -> AuthenticationError
+            is MarvelApiException ->
+                if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) NotFoundError
+                else UnknownServerError(Option.Some(e))
+            else -> UnknownServerError((Option.Some(e)))
+        }
 
 
-inline fun <reified F> fetchAllHeroes(C : Control<F> = control()): HK<F, List<CharacterDto>> =
-    C.binding {
-      val query = CharactersQuery.Builder.create().withOffset(0).withLimit(50).build()
-      val ctx = !C.ask()
-      C.catch(
-          { ctx.apiClient.getAll(query).response.characters },
-          { exceptionAsCharacterError(it) }
-      )
-    }
+fun fetchAllHeroes(): AsyncResult<List<CharacterDto>> =
+        AsyncResult.bind {
+            val query = CharactersQuery.Builder.create().withOffset(0).withLimit(50).build()
+            val ctx = !AsyncResult.ask()
+            AsyncResult.catch(
+                    { ctx.apiClient.getAll(query).response.characters },
+                    { exceptionAsCharacterError(it) }
+            ).ev()
+        }
 
-inline fun <reified F> fetchHeroesFromAvengerComics(C : Control<F> = control()): HK<F, List<CharacterDto>> =
-    C.map(fetchAllHeroes(), {
-      it.filter {
-        it.comics.items.map { it.name }.filter {
-          it.contains("Avenger", true)
-        }.count() > 0
-      }
-    })
+fun fetchHeroesFromAvengerComics(): AsyncResult<List<CharacterDto>> =
+        fetchAllHeroes().map {
+            it.filter {
+                it.comics.items.map { it.name }.filter {
+                    it.contains("Avenger", true)
+                }.count() > 0
+            }
+        }

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/UseCases.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/UseCases.kt
@@ -2,11 +2,12 @@ package com.github.jorgecastillo.kotlinandroid.domain.usecase
 
 import com.github.jorgecastillo.kotlinandroid.data.getHeroesFromAvengerComicsWithCachePolicy
 import com.github.jorgecastillo.kotlinandroid.data.getHeroesWithCachePolicy
+import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
 import com.karumi.marvelapiclient.model.CharacterDto
 import kategory.HK
 
-inline fun <reified F> getHeroesUseCase(): HK<F, List<CharacterDto>> =
+fun getHeroesUseCase(): AsyncResult<List<CharacterDto>> =
     getHeroesWithCachePolicy()
 
-inline fun <reified F> getHeroesFromAvengerComicsUseCase(): HK<F, List<CharacterDto>> =
+fun getHeroesFromAvengerComicsUseCase(): AsyncResult<List<CharacterDto>> =
     getHeroesFromAvengerComicsWithCachePolicy()

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/functional/predef.kt
@@ -4,72 +4,81 @@ import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
 import kategory.*
 
-typealias Control<F> = MonadControl<F, GetHeroesContext, CharacterError>
-
-inline fun <reified F> control(): Control<F> = monadControl()
-
 typealias AsyncResultKind<A> = HK<AsyncResult.F, A>
 
 fun <A> AsyncResultKind<A>.ev(): AsyncResult<A> =
-    this as AsyncResult<A>
+        this as AsyncResult<A>
 
 typealias Result<A> = Kleisli<EitherTF<Future.F, CharacterError>, GetHeroesContext, A>
 
 //There should be a monad error instance for EitherT in kategory
 class AsyncResult<A>(val value: Result<A>) : AsyncResultKind<A> {
-  class F private constructor()
-  companion object :
-      AsyncResultMonadControl,
-      GlobalInstance<MonadControl<AsyncResult.F, GetHeroesContext, CharacterError>>()
+    class F private constructor()
 
-  fun run(ctx: GetHeroesContext): HK<EitherTF<Future.F, CharacterError>, A> = value.run(ctx)
+    fun <B> map(f: (A) -> B): AsyncResult<B> =
+            map(this, f)
+
+    fun <B> product(fb: AsyncResult<B>): AsyncResult<Tuple2<A, B>> =
+            product(this, fb)
+
+    fun <B> flatMap(f: (A) -> AsyncResult<B>): AsyncResult<B> =
+            flatMap(this, f)
+
+    fun handleErrorWith(f: (CharacterError) -> AsyncResult<A>): AsyncResult<A> =
+            handleErrorWith(this, f)
+
+    fun handleError(f: (CharacterError) -> A): AsyncResult<A> =
+            handleError(this, f).ev()
+
+    companion object :
+            Monad<AsyncResult.F>,
+            MonadError<AsyncResult.F, CharacterError>,
+            MonadReader<AsyncResult.F, GetHeroesContext> {
+
+        fun ETM(): EitherTMonadError<Future.F, CharacterError> =
+                EitherTInstances(Future)
+
+        fun KM(): KleisliInstances<EitherTF<Future.F, CharacterError>, GetHeroesContext, CharacterError> =
+                KleisliInstances(ETM())
+
+        override fun <A, B> map(fa: AsyncResultKind<A>, f: (A) -> B): AsyncResult<B> =
+                AsyncResult(KM().map(fa.ev().value, f))
+
+        override fun <A, B> product(fa: AsyncResultKind<A>,
+                                    fb: AsyncResultKind<B>): AsyncResult<Tuple2<A, B>> =
+                AsyncResult(KM().product(fa.ev().value, fb.ev().value))
+
+        override fun <A, B> flatMap(fa: AsyncResultKind<A>,
+                                    f: (A) -> AsyncResultKind<B>): AsyncResult<B> =
+                AsyncResult(KM().flatMap(fa.ev().value, f.andThen { it.ev().value }))
+
+        override fun <A> handleErrorWith(fa: AsyncResultKind<A>,
+                                         f: (CharacterError) -> AsyncResultKind<A>): AsyncResult<A> =
+                AsyncResult(KM().handleErrorWith(fa.ev().value, f.andThen { it.ev().value }))
+
+        override fun <A, B> tailRecM(a: A, f: (A) -> AsyncResultKind<Either<A, B>>): AsyncResult<B> =
+                AsyncResult(KM().tailRecM(a, f.andThen { it.ev().value }))
+
+        override fun <A> raiseError(e: CharacterError): AsyncResult<A> =
+                AsyncResult(KM().raiseError<A>(e))
+
+        override fun <A> pure(a: A): AsyncResult<A> =
+                AsyncResult(KM().pure(a))
+
+        override fun ask(): AsyncResult<GetHeroesContext> =
+                AsyncResult(KM().ask())
+
+        val unit: AsyncResult<Unit> = pure(Unit)
+
+        override fun <A> local(
+                f: (GetHeroesContext) -> GetHeroesContext, fa: AsyncResultKind<A>): AsyncResult<A> =
+                AsyncResult(KM().local(f, fa.ev().value))
+
+        fun <B> bind(c: suspend MonadContinuation<AsyncResult.F, *>.() -> AsyncResult<B>): AsyncResult<B> =
+                binding(c).ev()
+
+    }
+
+    fun run(ctx: GetHeroesContext): HK<EitherTF<Future.F, CharacterError>, A> = value.run(ctx)
 }
 
-interface MonadControl<F, D, E> :
-    MonadError<F, E>,
-    MonadReader<F, D>,
-    Typeclass
-
-inline fun <reified F, reified D, reified E> monadControl(): MonadControl<F, D, E> =
-    instance(InstanceParametrizedType(MonadControl::class.java,
-        listOf(F::class.java, D::class.java, E::class.java)))
-
-interface AsyncResultMonadControl : MonadControl<AsyncResult.F, GetHeroesContext, CharacterError> {
-
-  fun ETM(): EitherTMonadError<Future.F, CharacterError> =
-      EitherTInstances(Future)
-
-  fun KM(): KleisliInstances<EitherTF<Future.F, CharacterError>, GetHeroesContext, CharacterError> =
-      KleisliInstances(ETM())
-
-  override fun <A, B> map(fa: HK<AsyncResult.F, A>, f: (A) -> B): AsyncResult<B> =
-      AsyncResult(KM().map(fa.ev().value, f))
-
-  override fun <A, B> product(fa: HK<AsyncResult.F, A>,
-      fb: HK<AsyncResult.F, B>): AsyncResult<Tuple2<A, B>> =
-      AsyncResult(KM().product(fa.ev().value, fb.ev().value))
-
-  override fun <A, B> flatMap(fa: HK<AsyncResult.F, A>,
-      f: (A) -> HK<AsyncResult.F, B>): AsyncResult<B> =
-      AsyncResult(KM().flatMap(fa.ev().value, f.andThen { it.ev().value }))
-
-  override fun <A> handleErrorWith(fa: HK<AsyncResult.F, A>,
-      f: (CharacterError) -> HK<AsyncResult.F, A>): AsyncResult<A> =
-      AsyncResult(KM().handleErrorWith(fa.ev().value, f.andThen { it.ev().value }))
-
-  override fun <A, B> tailRecM(a: A, f: (A) -> HK<AsyncResult.F, Either<A, B>>): AsyncResult<B> =
-      AsyncResult(KM().tailRecM(a, f.andThen { it.ev().value }))
-
-  override fun <A> raiseError(e: CharacterError): AsyncResult<A> =
-      AsyncResult(KM().raiseError<A>(e))
-
-  override fun <A> pure(a: A): AsyncResult<A> =
-      AsyncResult(KM().pure(a))
-
-  override fun ask(): AsyncResult<GetHeroesContext> =
-      AsyncResult(KM().ask())
-
-  override fun <A> local(f: (GetHeroesContext) -> GetHeroesContext,
-      fa: HK<AsyncResult.F, A>): AsyncResult<A> =
-      AsyncResult(KM().local(f, fa.ev().value))
-}

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
@@ -1,43 +1,51 @@
 package com.github.jorgecastillo.kotlinandroid.presentation
 
-import com.github.jorgecastillo.kotlinandroid.di.context.GetHeroesContext
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.*
 import com.github.jorgecastillo.kotlinandroid.domain.usecase.getHeroesUseCase
-import com.github.jorgecastillo.kotlinandroid.functional.Control
-import com.github.jorgecastillo.kotlinandroid.functional.monadControl
+import com.github.jorgecastillo.kotlinandroid.functional.AsyncResult
 import com.github.jorgecastillo.kotlinandroid.view.viewmodel.SuperHeroViewModel
+import com.karumi.marvelapiclient.model.CharacterDto
 import com.karumi.marvelapiclient.model.MarvelImage
-import kategory.HK
-import kategory.binding
 
 interface SuperHeroesView {
 
-  fun drawHeroes(heroes: List<SuperHeroViewModel>)
+    fun drawHeroes(heroes: List<SuperHeroViewModel>): Unit
 
-  fun showHeroesNotFoundError()
+    fun showHeroesNotFoundError(): Unit
 
-  fun showGenericError()
+    fun showGenericError(): Unit
 
-  fun showAuthenticationError()
+    fun showAuthenticationError(): Unit
 }
 
-fun displayErrors(ctx: GetHeroesContext, c: CharacterError) : Unit {
-  when (c) {
-    is NotFoundError -> ctx.view.showHeroesNotFoundError()
-    is UnknownServerError -> ctx.view.showGenericError()
-    is AuthenticationError -> ctx.view.showAuthenticationError()
-  }
-}
-
-inline fun <reified F> getSuperHeroes(C: Control<F> = monadControl()): HK<F, Unit> =
-    C.binding {
-      val ctx = !C.ask()
-      val result = !C.handleError(getHeroesUseCase(), { displayErrors(ctx, it); emptyList()})
-      ctx.view.drawHeroes(result.map {
-        SuperHeroViewModel(
-            it.name,
-            it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY))
-      })
-      C.pure(Unit)
+fun displayErrors(c: CharacterError): AsyncResult<Unit> =
+    AsyncResult.bind {
+        val ctx = AsyncResult.ask().bind()
+        when (c) {
+            is NotFoundError -> ctx.view.showHeroesNotFoundError()
+            is UnknownServerError -> ctx.view.showGenericError()
+            is AuthenticationError -> ctx.view.showAuthenticationError()
+        }
+        AsyncResult.unit
     }
+
+fun drawHeroes(heroes : List<SuperHeroViewModel>): AsyncResult<Unit> =
+        AsyncResult.bind {
+            val ctx = AsyncResult.ask().bind()
+            ctx.view.drawHeroes(heroes)
+            AsyncResult.unit
+        }
+
+fun charactersToHeroes(characters: List<CharacterDto>) : List<SuperHeroViewModel> =
+        characters.map {
+            SuperHeroViewModel(
+                    it.name,
+                    it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY))
+        }
+
+fun getSuperHeroes(): AsyncResult<Unit> =
+        getHeroesUseCase()
+                .map(::charactersToHeroes)
+                .flatMap(::drawHeroes)
+                .handleErrorWith(::displayErrors)

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroListActivity.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroListActivity.kt
@@ -33,23 +33,23 @@ class SuperHeroListActivity : AppCompatActivity(), SuperHeroesView {
 
   override fun onResume() {
     super.onResume()
-    getSuperHeroes(AsyncResult).ev().run(GetHeroesContext(this))
+    getSuperHeroes().run(GetHeroesContext(this))
   }
 
-  override fun drawHeroes(heroes: List<SuperHeroViewModel>) {
+  override fun drawHeroes(heroes: List<SuperHeroViewModel>) = runOnUiThread {
     adapter.characters = heroes
     adapter.notifyDataSetChanged()
   }
 
-  override fun showHeroesNotFoundError() {
+  override fun showHeroesNotFoundError() = runOnUiThread {
     Snackbar.make(heroesList, R.string.not_found, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showGenericError() {
+  override fun showGenericError() = runOnUiThread {
     Snackbar.make(heroesList, R.string.generic, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showAuthenticationError() {
+  override fun showAuthenticationError() = runOnUiThread {
     Snackbar.make(heroesList, R.string.authentication, Snackbar.LENGTH_SHORT).show()
   }
 }


### PR DESCRIPTION
The following PR encapsulates the application concerns in a single datatype representing a Monad transformer that allows monadic computation and encapsulation of the following Application concerns:
```kotlin
typealias Result<A> = Kleisli<EitherTF<Future.F, CharacterError>, GetHeroesContext, A>
```
An Async Result can handle dependency injection of `GetHeroesContext` values thanks to `Kleisli` which is the same as a Reader monad but parametric to other monads in this case `Future` whereas `Reader` is parametric to the `Id` monad.

An `AsyncResult` is a `MonadError<AsyncResult.F, CharacterError>` able to handle and raise errors in the context of `CharacterError`.

The nested `EitherT` over `Future` allows us to bind directly to the underlying `A` value when using `flatMap` and monadic comprehensions.

This PR also demonstrate the use of monadic comprehensions thanks to [kategory](https://github.com/kategory/kategory) a typed FP library for the Kotlin programming language.


