### PR TITLE
Remove Future on Nested Monads module

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ strategies / gradle modules available.
 
 ## Nested Monads
 On this module, you will find a not very common approach using nested Monads like `Reader`, 
-`Future`, or `Either` to construct the asynchronous result I want to get. This module showcases 
+`IO`, or `Either` to construct the asynchronous result I want to get. This module showcases 
 the first natural step that any OOP Android developer would probably implement on his first attempt 
 to use Monads. You need some nested behaviors, so you move on and nest them. But in the end, It's 
 not a quite common approach on FP, since we usually would end up combining all the properties from 

--- a/free-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
+++ b/free-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
@@ -43,21 +43,21 @@ class SuperHeroDetailActivity : AppCompatActivity(), SuperHeroDetailView {
     Toast.makeText(this, string.hero_id_needed, Toast.LENGTH_SHORT).show()
   }
 
-  override fun drawHero(hero: SuperHeroViewModel) {
+  override fun drawHero(hero: SuperHeroViewModel) = runOnUiThread  {
     collapsingToolbar.title = hero.name
     description.text = hero.description.let { if (it.isNotEmpty()) it else getString(string.empty_description) }
     headerImage.loadImageAsync(hero.photoUrl)
   }
 
-  override fun showNotFoundError() {
+  override fun showNotFoundError() = runOnUiThread  {
     Snackbar.make(appBar, string.not_found, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showGenericError() {
+  override fun showGenericError() = runOnUiThread  {
     Snackbar.make(appBar, string.generic, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showAuthenticationError() {
+  override fun showAuthenticationError() = runOnUiThread  {
     Snackbar.make(appBar, string.authentication, Snackbar.LENGTH_SHORT).show()
   }
 }

--- a/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
+++ b/monad-transformers/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
@@ -46,21 +46,21 @@ class SuperHeroDetailActivity : AppCompatActivity(), SuperHeroDetailView {
     Toast.makeText(this, string.hero_id_needed, Toast.LENGTH_SHORT).show()
   }
 
-  override fun drawHero(hero: SuperHeroViewModel) {
+  override fun drawHero(hero: SuperHeroViewModel) = runOnUiThread {
     collapsingToolbar.title = hero.name
     description.text = hero.description.let { if (it.isNotEmpty()) it else getString(string.empty_description) }
     headerImage.loadImageAsync(hero.photoUrl)
   }
 
-  override fun showNotFoundError() {
+  override fun showNotFoundError() = runOnUiThread  {
     Snackbar.make(appBar, string.not_found, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showGenericError() {
+  override fun showGenericError() = runOnUiThread  {
     Snackbar.make(appBar, string.generic, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showAuthenticationError() {
+  override fun showAuthenticationError() = runOnUiThread  {
     Snackbar.make(appBar, string.authentication, Snackbar.LENGTH_SHORT).show()
   }
 }

--- a/nested-monads/build.gradle
+++ b/nested-monads/build.gradle
@@ -77,6 +77,7 @@ dependencies {
   compile "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion"
   compile "com.squareup.picasso:picasso:2.5.2"
   compile "io.kategory:kategory-annotations:$kategory_version"
+  compile "io.kategory:kategory-effects:$kategory_version"
   compile "io.kategory:kategory:$kategory_version"
   compile 'com.karumi:marvelapiclient:1.0.1'
 }

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/data/HeroesRepository.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/data/HeroesRepository.kt
@@ -6,7 +6,6 @@ import com.github.jorgecastillo.kotlinandroid.data.CachePolicy.NetworkFirst
 import com.github.jorgecastillo.kotlinandroid.data.CachePolicy.NetworkOnly
 import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchAllHeroes
 import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchHeroDetails
-import com.github.jorgecastillo.kotlinandroid.data.datasource.remote.fetchHeroesFromAvengerComics
 
 sealed class CachePolicy {
   object NetworkOnly : CachePolicy()
@@ -27,11 +26,4 @@ fun getHeroDetails(policy: CachePolicy, heroId: String) = when (policy) {
   is NetworkFirst -> fetchHeroDetails(heroId) // TODO change to conditional call
   is LocalOnly -> fetchHeroDetails(heroId) // TODO change to local only cache call
   is LocalFirst -> fetchHeroDetails(heroId) // TODO change to conditional call
-}
-
-fun getHeroesFromAvengerComics(policy: CachePolicy) = when (policy) {
-  is NetworkOnly -> fetchHeroesFromAvengerComics()
-  is NetworkFirst -> fetchHeroesFromAvengerComics() // TODO change to conditional call
-  is LocalOnly -> fetchHeroesFromAvengerComics() // TODO change to local only cache call
-  is LocalFirst -> fetchHeroesFromAvengerComics() // TODO change to conditional call
 }

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
@@ -2,18 +2,25 @@ package com.github.jorgecastillo.kotlinandroid.data.datasource.remote
 
 import com.github.jorgecastillo.kotlinandroid.di.context.SuperHeroesContext.GetHeroDetailsContext
 import com.github.jorgecastillo.kotlinandroid.di.context.SuperHeroesContext.GetHeroesContext
+import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.AuthenticationError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.NotFoundError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.UnknownServerError
-import com.github.jorgecastillo.kotlinandroid.functional.Future
 import com.karumi.marvelapiclient.MarvelApiException
 import com.karumi.marvelapiclient.MarvelAuthApiException
 import com.karumi.marvelapiclient.model.CharacterDto
-import com.karumi.marvelapiclient.model.CharactersQuery
+import com.karumi.marvelapiclient.model.CharactersQuery.Builder
+import kategory.Either
 import kategory.Either.Left
 import kategory.Either.Right
-import kategory.*
+import kategory.HK
 import kategory.Reader
+import kategory.Try
+import kategory.effects.AsyncContext
+import kategory.map
+import kategory.right
+import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.async
 import java.net.HttpURLConnection
 
 /*
@@ -30,49 +37,52 @@ import java.net.HttpURLConnection
  */
 
 fun fetchAllHeroes() = Reader.ask<GetHeroesContext>().map({ ctx ->
-  Future {
-    try {
-      val query = CharactersQuery.Builder.create().withOffset(0).withLimit(50).build()
-      Right<List<CharacterDto>>(ctx.apiClient.getAll(query).response.characters)
-    } catch (e: MarvelAuthApiException) {
-      Left(AuthenticationError())
-    } catch (e: MarvelApiException) {
-      if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) {
-        Left(NotFoundError())
-      } else {
-        Left(UnknownServerError())
-      }
-    }
-  }
+  runInAsyncContext(
+      { queryForHeroes(ctx) },
+      { mapExceptionsToDomainErrors(it) },
+      { Right(it) },
+      ctx.threading)
 })
 
 fun fetchHeroDetails(heroId: String) = Reader.ask<GetHeroDetailsContext>().map({ ctx ->
-  Future {
-    try {
-      Right<List<CharacterDto>>(listOf(ctx.apiClient.getCharacter(heroId).response))
-    } catch (e: MarvelAuthApiException) {
-      Left(AuthenticationError())
-    } catch (e: MarvelApiException) {
-      if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) {
-        Left(NotFoundError())
-      } else {
-        Left(UnknownServerError())
-      }
-    }
-  }
+  runInAsyncContext(
+      { queryForHero(ctx, heroId) },
+      { mapExceptionsToDomainErrors(it) },
+      { Right(it) },
+      ctx.threading)
 })
 
-fun fetchHeroesFromAvengerComics() = fetchAllHeroes().map({ future ->
-  future.map {
-    when (it) {
-      is Right -> it.map {
-        it.filter {
-          it.comics.items.map { it.name }.filter {
-            it.contains("Avenger", true)
-          }.count() > 0
-        }
-      }
-      is Left -> it
+private fun queryForHeroes(ctx: GetHeroesContext): List<CharacterDto> {
+  val query = Builder.create().withOffset(0).withLimit(50).build()
+  return ctx.apiClient.getAll(query).response.characters
+}
+
+private fun queryForHero(ctx: GetHeroDetailsContext, heroId: String): List<CharacterDto> =
+    listOf(ctx.apiClient.getCharacter(heroId).response)
+
+private fun mapExceptionsToDomainErrors(
+    it: Throwable): Either<CharacterError, Nothing> {
+  return when (it as MarvelApiException) {
+    is MarvelAuthApiException -> Left(AuthenticationError())
+    else -> if (it.httpCode == HttpURLConnection.HTTP_NOT_FOUND) {
+      Left(NotFoundError())
+    } else {
+      Left(UnknownServerError())
     }
   }
-})
+}
+
+/**
+ * Just syntax to improve readability.
+ */
+private fun <F, A, B> runInAsyncContext(
+    f: () -> A,
+    onError: (Throwable) -> B,
+    onSuccess: (A) -> B, AC: AsyncContext<F>): HK<F, B> {
+  return AC.runAsync { proc ->
+    async(CommonPool) {
+      val result = Try { f() }.fold(onError, onSuccess)
+      proc(result.right())
+    }
+  }
+}

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/data/datasource/remote/MarvelNetworkDataSource.kt
@@ -16,7 +16,10 @@ import kategory.Either.Right
 import kategory.HK
 import kategory.Reader
 import kategory.Try
+import kategory.bindingE
 import kategory.effects.AsyncContext
+import kategory.effects.IO
+import kategory.effects.monadError
 import kategory.map
 import kategory.right
 import kotlinx.coroutines.experimental.CommonPool
@@ -37,19 +40,23 @@ import java.net.HttpURLConnection
  */
 
 fun fetchAllHeroes() = Reader.ask<GetHeroesContext>().map({ ctx ->
-  runInAsyncContext(
-      { queryForHeroes(ctx) },
-      { mapExceptionsToDomainErrors(it) },
-      { Right(it) },
-      ctx.threading)
+  IO.monadError().bindingE {
+    runInAsyncContext(
+        { queryForHeroes(ctx) },
+        { mapExceptionsToDomainErrors(it) },
+        { Right(it) },
+        ctx.threading)
+  }
 })
 
 fun fetchHeroDetails(heroId: String) = Reader.ask<GetHeroDetailsContext>().map({ ctx ->
-  runInAsyncContext(
-      { queryForHero(ctx, heroId) },
-      { mapExceptionsToDomainErrors(it) },
-      { Right(it) },
-      ctx.threading)
+  IO.monadError().bindingE {
+    runInAsyncContext(
+        { queryForHero(ctx, heroId) },
+        { mapExceptionsToDomainErrors(it) },
+        { Right(it) },
+        ctx.threading)
+  }
 })
 
 private fun queryForHeroes(ctx: GetHeroesContext): List<CharacterDto> {

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/di/context/SuperHeroesContext.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/di/context/SuperHeroesContext.kt
@@ -7,6 +7,8 @@ import com.github.jorgecastillo.kotlinandroid.presentation.SuperHeroesListView
 import com.github.jorgecastillo.kotlinandroid.presentation.navigation.HeroDetailsPage
 import com.karumi.marvelapiclient.CharacterApiClient
 import com.karumi.marvelapiclient.MarvelApiConfig
+import kategory.effects.IO
+import kategory.effects.asyncContext
 
 sealed class SuperHeroesContext(ctx: Context) {
 
@@ -15,6 +17,7 @@ sealed class SuperHeroesContext(ctx: Context) {
     get() = CharacterApiClient(MarvelApiConfig.Builder(
         BuildConfig.MARVEL_PUBLIC_KEY,
         BuildConfig.MARVEL_PRIVATE_KEY).debug().build())
+  val threading = IO.asyncContext()
 
   data class GetHeroesContext(val ctx: Context, val view: SuperHeroesListView) : SuperHeroesContext(ctx)
   data class GetHeroDetailsContext(val ctx: Context, val view: SuperHeroDetailView) : SuperHeroesContext(ctx)

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/model/CharacterError.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/model/CharacterError.kt
@@ -1,5 +1,7 @@
 package com.github.jorgecastillo.kotlinandroid.domain.model
 
+import kategory.Option
+
 /**
  * This sealed class represents all the possible errors that the app is going to model inside its
  * domain. All the exceptions / errors provoked by third party libraries or APIs are mapped to any
@@ -13,7 +15,7 @@ package com.github.jorgecastillo.kotlinandroid.domain.model
  * bring not required complexity to the architecture introducing asynchronous semantics.
  */
 sealed class CharacterError {
-  class AuthenticationError : CharacterError()
-  class NotFoundError : CharacterError()
-  class UnknownServerError : CharacterError()
+  object AuthenticationError : CharacterError()
+  object NotFoundError : CharacterError()
+  data class UnknownServerError(val e: Option<Throwable> = Option.None) : CharacterError()
 }

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/HeroesUseCases.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/HeroesUseCases.kt
@@ -3,18 +3,15 @@ package com.github.jorgecastillo.kotlinandroid.domain.usecase
 import com.github.jorgecastillo.kotlinandroid.data.CachePolicy.NetworkOnly
 import com.github.jorgecastillo.kotlinandroid.data.getHeroDetails
 import com.github.jorgecastillo.kotlinandroid.data.getHeroes
-import com.github.jorgecastillo.kotlinandroid.data.getHeroesFromAvengerComics
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
 import com.karumi.marvelapiclient.model.CharacterDto
 import com.karumi.marvelapiclient.model.MarvelImage
 import kategory.Either
 import kategory.Either.Left
 import kategory.Either.Right
-import kategory.*
+import kategory.map
 
-fun getHeroesUseCase() = getHeroes(NetworkOnly).map({ future ->
-  future.map { discardNonValidHeroes(it) }
-})
+fun getHeroesUseCase() = getHeroes(NetworkOnly).map { it.map { discardNonValidHeroes(it) } }
 
 private fun discardNonValidHeroes(maybeHeroes: Either<CharacterError, List<CharacterDto>>) =
     when (maybeHeroes) {
@@ -29,6 +26,3 @@ private fun discardNonValidHeroes(maybeHeroes: Either<CharacterError, List<Chara
 
 fun getHeroDetailsUseCase(heroId: String) = getHeroDetails(NetworkOnly, heroId)
 
-fun getHeroesFromAvengerComicsUseCase() = getHeroesFromAvengerComics(NetworkOnly).map({ future ->
-  future.map { discardNonValidHeroes(it) }
-})

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/HeroesUseCases.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/domain/usecase/HeroesUseCases.kt
@@ -3,26 +3,18 @@ package com.github.jorgecastillo.kotlinandroid.domain.usecase
 import com.github.jorgecastillo.kotlinandroid.data.CachePolicy.NetworkOnly
 import com.github.jorgecastillo.kotlinandroid.data.getHeroDetails
 import com.github.jorgecastillo.kotlinandroid.data.getHeroes
-import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
 import com.karumi.marvelapiclient.model.CharacterDto
 import com.karumi.marvelapiclient.model.MarvelImage
-import kategory.Either
-import kategory.Either.Left
-import kategory.Either.Right
 import kategory.map
 
-fun getHeroesUseCase() = getHeroes(NetworkOnly).map { it.map { discardNonValidHeroes(it) } }
+fun getHeroesUseCase() = getHeroes(NetworkOnly).map { io -> io.map { discardNonValidHeroes(it) } }
 
-private fun discardNonValidHeroes(maybeHeroes: Either<CharacterError, List<CharacterDto>>) =
-    when (maybeHeroes) {
-      is Right -> maybeHeroes.map {
-        it.filter {
-          !it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY)
-              .contains("image_not_available", true)
-        }
-      }
-      is Left -> maybeHeroes
+private fun discardNonValidHeroes(heroes: List<CharacterDto>) =
+    heroes.filter {
+      !it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY)
+          .contains("image_not_available", true)
     }
+
 
 fun getHeroDetailsUseCase(heroId: String) = getHeroDetails(NetworkOnly, heroId)
 

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
@@ -33,8 +33,8 @@ fun onHeroListItemClick(heroId: String) = Reader.ask<GetHeroesContext>().flatMap
 })
 
 fun getSuperHeroes() = Reader.ask<GetHeroesContext>().flatMap({ (_, view: SuperHeroesListView) ->
-  getHeroesUseCase().map({ res ->
-    res.ev().unsafeRunAsync {
+  getHeroesUseCase().map({ io ->
+    io.ev().unsafeRunAsync {
       it.map {
         it.fold({ error ->
           when (error) {
@@ -58,8 +58,8 @@ fun getSuperHeroes() = Reader.ask<GetHeroesContext>().flatMap({ (_, view: SuperH
 
 fun getSuperHeroDetails(heroId: String) = Reader.ask<GetHeroDetailsContext>()
     .flatMap({ (_, view: SuperHeroDetailView) ->
-      getHeroDetailsUseCase(heroId).map({ res ->
-        res.ev().unsafeRunAsync {
+      getHeroDetailsUseCase(heroId).map({ io ->
+        io.ev().unsafeRunAsync {
           it.map {
             it.fold({ error ->
               when (error) {

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/presentation/SuperHeroesPresentation.kt
@@ -2,17 +2,23 @@ package com.github.jorgecastillo.kotlinandroid.presentation
 
 import com.github.jorgecastillo.kotlinandroid.di.context.SuperHeroesContext.GetHeroDetailsContext
 import com.github.jorgecastillo.kotlinandroid.di.context.SuperHeroesContext.GetHeroesContext
+import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.AuthenticationError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.NotFoundError
 import com.github.jorgecastillo.kotlinandroid.domain.model.CharacterError.UnknownServerError
 import com.github.jorgecastillo.kotlinandroid.domain.usecase.getHeroDetailsUseCase
 import com.github.jorgecastillo.kotlinandroid.domain.usecase.getHeroesUseCase
 import com.github.jorgecastillo.kotlinandroid.view.viewmodel.SuperHeroViewModel
+import com.karumi.marvelapiclient.MarvelApiException
+import com.karumi.marvelapiclient.MarvelAuthApiException
 import com.karumi.marvelapiclient.model.MarvelImage
+import kategory.Option
 import kategory.Reader
 import kategory.effects.ev
 import kategory.flatMap
+import kategory.identity
 import kategory.map
+import java.net.HttpURLConnection
 
 interface HeroesView {
   fun showNotFoundError()
@@ -34,24 +40,22 @@ fun onHeroListItemClick(heroId: String) = Reader.ask<GetHeroesContext>().flatMap
 
 fun getSuperHeroes() = Reader.ask<GetHeroesContext>().flatMap({ (_, view: SuperHeroesListView) ->
   getHeroesUseCase().map({ io ->
-    io.ev().unsafeRunAsync {
-      it.map {
-        it.fold({ error ->
-          when (error) {
-            is NotFoundError -> view.showNotFoundError()
-            is UnknownServerError -> view.showGenericError()
-            is AuthenticationError -> view.showAuthenticationError()
-          }
-        }, { success ->
-          view.drawHeroes(success.map {
-            SuperHeroViewModel(
-                it.id,
-                it.name,
-                it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY),
-                it.description)
-          })
+    io.ev().unsafeRunAsync { maybeHeroes ->
+      maybeHeroes.bimap(::exceptionAsCharacterError, ::identity).fold({ error ->
+        when (error) {
+          is NotFoundError -> view.showNotFoundError()
+          is UnknownServerError -> view.showGenericError()
+          is AuthenticationError -> view.showAuthenticationError()
+        }
+      }, { success ->
+        view.drawHeroes(success.map {
+          SuperHeroViewModel(
+              it.id,
+              it.name,
+              it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY),
+              it.description)
         })
-      }
+      })
     }
   })
 })
@@ -59,24 +63,31 @@ fun getSuperHeroes() = Reader.ask<GetHeroesContext>().flatMap({ (_, view: SuperH
 fun getSuperHeroDetails(heroId: String) = Reader.ask<GetHeroDetailsContext>()
     .flatMap({ (_, view: SuperHeroDetailView) ->
       getHeroDetailsUseCase(heroId).map({ io ->
-        io.ev().unsafeRunAsync {
-          it.map {
-            it.fold({ error ->
-              when (error) {
-                is NotFoundError -> view.showNotFoundError()
-                is UnknownServerError -> view.showGenericError()
-                is AuthenticationError -> view.showAuthenticationError()
-              }
-            }, { success ->
-              view.drawHero(success.map {
-                SuperHeroViewModel(
-                    it.id,
-                    it.name,
-                    it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY),
-                    it.description)
-              }.first())
-            })
-          }
+        io.ev().unsafeRunAsync { maybeHeroes ->
+          maybeHeroes.bimap(::exceptionAsCharacterError, ::identity).fold({ error ->
+            when (error) {
+              is NotFoundError -> view.showNotFoundError()
+              is UnknownServerError -> view.showGenericError()
+              is AuthenticationError -> view.showAuthenticationError()
+            }
+          }, { success ->
+            view.drawHero(success.map {
+              SuperHeroViewModel(
+                  it.id,
+                  it.name,
+                  it.thumbnail.getImageUrl(MarvelImage.Size.PORTRAIT_UNCANNY),
+                  it.description)
+            }.first())
+          })
         }
       })
     })
+
+fun exceptionAsCharacterError(e: Throwable): CharacterError =
+    when (e) {
+      is MarvelAuthApiException -> CharacterError.AuthenticationError
+      is MarvelApiException ->
+        if (e.httpCode == HttpURLConnection.HTTP_NOT_FOUND) CharacterError.NotFoundError
+        else CharacterError.UnknownServerError(Option.Some(e))
+      else -> CharacterError.UnknownServerError((Option.Some(e)))
+    }

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
@@ -47,21 +47,21 @@ class SuperHeroDetailActivity : AppCompatActivity(), SuperHeroDetailView {
     Toast.makeText(this, string.hero_id_needed, Toast.LENGTH_SHORT).show()
   }
 
-  override fun drawHero(hero: SuperHeroViewModel) {
+  override fun drawHero(hero: SuperHeroViewModel) = runOnUiThread {
     collapsingToolbar.title = hero.name
     description.text = hero.description.let { if (it.isNotEmpty()) it else getString(R.string.empty_description) }
     headerImage.loadImageAsync(hero.photoUrl)
   }
 
-  override fun showNotFoundError() {
+  override fun showNotFoundError() = runOnUiThread {
     Snackbar.make(appBar, string.not_found, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showGenericError() {
+  override fun showGenericError() = runOnUiThread {
     Snackbar.make(appBar, string.generic, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showAuthenticationError() {
+  override fun showAuthenticationError() = runOnUiThread {
     Snackbar.make(appBar, string.authentication, Snackbar.LENGTH_SHORT).show()
   }
 }

--- a/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroListActivity.kt
+++ b/nested-monads/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroListActivity.kt
@@ -43,20 +43,20 @@ class SuperHeroListActivity : AppCompatActivity(), SuperHeroesListView {
     getSuperHeroes().run(heroesContext)
   }
 
-  override fun drawHeroes(heroes: List<SuperHeroViewModel>) {
+  override fun drawHeroes(heroes: List<SuperHeroViewModel>) = runOnUiThread {
     adapter.characters = heroes
     adapter.notifyDataSetChanged()
   }
 
-  override fun showNotFoundError() {
+  override fun showNotFoundError() = runOnUiThread{
     Snackbar.make(heroesList, R.string.not_found, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showGenericError() {
+  override fun showGenericError() = runOnUiThread{
     Snackbar.make(heroesList, R.string.generic, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showAuthenticationError() {
+  override fun showAuthenticationError() = runOnUiThread{
     Snackbar.make(heroesList, R.string.authentication, Snackbar.LENGTH_SHORT).show()
   }
 }

--- a/tagless-final/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
+++ b/tagless-final/src/main/java/com/github/jorgecastillo/kotlinandroid/view/SuperHeroDetailActivity.kt
@@ -48,21 +48,21 @@ class SuperHeroDetailActivity : AppCompatActivity(), SuperHeroDetailView {
     Toast.makeText(this, string.hero_id_needed, Toast.LENGTH_SHORT).show()
   }
 
-  override fun drawHero(hero: SuperHeroViewModel) {
+  override fun drawHero(hero: SuperHeroViewModel) = runOnUiThread  {
     collapsingToolbar.title = hero.name
     description.text = hero.description.let { if (it.isNotEmpty()) it else getString(string.empty_description) }
     headerImage.loadImageAsync(hero.photoUrl)
   }
 
-  override fun showNotFoundError() {
+  override fun showNotFoundError() = runOnUiThread  {
     Snackbar.make(appBar, string.not_found, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showGenericError() {
+  override fun showGenericError() = runOnUiThread  {
     Snackbar.make(appBar, string.generic, Snackbar.LENGTH_SHORT).show()
   }
 
-  override fun showAuthenticationError() {
+  override fun showAuthenticationError() = runOnUiThread  {
     Snackbar.make(appBar, string.authentication, Snackbar.LENGTH_SHORT).show()
   }
 }


### PR DESCRIPTION
fixes #8 

Given that we have `kategory-effects`, it's better to play with those resources instead of coding our own `Future` decaffeinated version.

I am trying to replace it here with `IO` and `AsyncContext` usage.