### PR TITLE
Upgrade to Arrow 0.7.2 and downgrade Dagger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
   ext.kotlin_version = '1.2.41'
-  ext.arrow_version = '0.7.1'
-  ext.dagger_version = '2.5'
+  ext.arrow_version = '0.7.2'
+  ext.dagger_version = '2.15'
   ext.supportLibrary = '27.0.2'
   ext.coroutinesVersion = '0.16'
   ext.build_tools_version = '27.0.3'


### PR DESCRIPTION
* Upgraded to Arrow `0.7.2`.
* Downgraded Dagger to `2.15` (the version Arrow uses atm) because of some compilation problems with `@Provides` annotations using a `type` parameter that is not available on dagger 2 anymore in version `2.5`.