### PR TITLE
Fix AS 3.1.2 failing to resolve `common` and `runtime`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ buildscript {
   ext.testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
 
   repositories {
+    google()
     maven { url "http://dl.bintray.com/kategory/maven" }
     jcenter()
-    google()
     maven { url 'https://oss.jfrog.org/oss-snapshot-local/' }
   }
 
@@ -29,10 +29,10 @@ buildscript {
 
 allprojects {
   repositories {
+    google()
     jcenter()
     mavenCentral()
     maven { url "http://dl.bintray.com/kategory/maven" }
-    maven { url 'https://maven.google.com' }
     maven { url 'https://kotlin.bintray.com/kotlinx' }
     maven { url "http://dl.bintray.com/kotlin/kotlin-dev" }
     maven { url 'https://oss.jfrog.org/oss-snapshot-local/' }


### PR DESCRIPTION
Apparently since AS 3.1.2 there are problems with building projects when `google()` is not the first repository in `build.gradle` repositories list (as discussed here on Stack Overflow):
https://stackoverflow.com/questions/50584437/android-studio-3-1-2-failed-to-resolve-runtime
This PR rearranges `google()` repository to the top of the list so the project builds correctly again.
It resolves issue #24 .