### PR TITLE
David/suspend

### DIFF
--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/io/algebras/ui/Presentation.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/io/algebras/ui/Presentation.kt
@@ -11,25 +11,25 @@ import com.github.jorgecastillo.kotlinandroid.io.runtime.context.Runtime
 
 interface NewsView {
 
-    fun showLoading(): Unit
+    suspend fun showLoading(): Unit
 
-    fun hideLoading(): Unit
+    suspend fun hideLoading(): Unit
 
-    fun showNotFoundError(): Unit
+    suspend fun showNotFoundError(): Unit
 
-    fun showGenericError(): Unit
+    suspend fun showGenericError(): Unit
 
-    fun showAuthenticationError(): Unit
+    suspend fun showAuthenticationError(): Unit
 }
 
 interface NewsListView : NewsView {
 
-    fun drawNews(news: List<NewsItemViewState>): Unit
+    suspend fun drawNews(news: List<NewsItemViewState>): Unit
 }
 
 interface NewsItemDetailView : NewsView {
 
-    fun drawNewsItem(newsItem: NewsItemViewState)
+    suspend fun drawNewsItem(newsItem: NewsItemViewState)
 }
 
 /**
@@ -43,7 +43,7 @@ fun <F> Runtime<F>.onNewsItemClick(
 ): Kind<F, Unit> =
     goToNewsItemDetail(ctx, title)
 
-private fun displayErrors(
+private suspend fun displayErrors(
     view: NewsView,
     t: Throwable
 ): Unit {

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/io/runtime/ui/AndroidNewsListActivity.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/io/runtime/ui/AndroidNewsListActivity.kt
@@ -54,28 +54,28 @@ class AndroidNewsListActivity : AppCompatActivity(), NewsListView {
         }
     }
 
-    override fun showLoading() {
+    override suspend fun showLoading() {
         loader.visibility = View.VISIBLE
     }
 
-    override fun hideLoading() {
+    override suspend fun hideLoading() {
         loader.visibility = View.GONE
     }
 
-    override fun drawNews(news: List<NewsItemViewState>) {
+    override suspend fun drawNews(news: List<NewsItemViewState>) {
         adapter.news = news
         adapter.notifyDataSetChanged()
     }
 
-    override fun showNotFoundError() {
+    override suspend fun showNotFoundError() {
         Snackbar.make(newsList, R.string.not_found, Snackbar.LENGTH_SHORT).show()
     }
 
-    override fun showGenericError() {
+    override suspend fun showGenericError() {
         Snackbar.make(newsList, R.string.generic, Snackbar.LENGTH_SHORT).show()
     }
 
-    override fun showAuthenticationError() {
+    override suspend fun showAuthenticationError() {
         Snackbar.make(newsList, R.string.authentication, Snackbar.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/java/com/github/jorgecastillo/kotlinandroid/io/runtime/ui/NewsItemDetailActivity.kt
+++ b/app/src/main/java/com/github/jorgecastillo/kotlinandroid/io/runtime/ui/NewsItemDetailActivity.kt
@@ -66,29 +66,29 @@ class NewsItemDetailActivity : AppCompatActivity(), NewsItemDetailView {
         Toast.makeText(this, string.news_id_needed, Toast.LENGTH_SHORT).show()
     }
 
-    override fun showLoading() {
+    override suspend fun showLoading() {
         loader.visibility = View.VISIBLE
     }
 
-    override fun hideLoading() {
+    override suspend fun hideLoading() {
         loader.visibility = View.GONE
     }
 
-    override fun drawNewsItem(newsItem: NewsItemViewState) {
+    override suspend fun drawNewsItem(newsItem: NewsItemViewState) {
         collapsingToolbar.title = newsItem.title
         description.text = newsItem.description ?: getString(string.empty_description)
         newsItem.photoUrl?.let { url -> headerImage.loadImageAsync(url) }
     }
 
-    override fun showNotFoundError() {
+    override suspend fun showNotFoundError() {
         Snackbar.make(appBar, string.not_found, Snackbar.LENGTH_SHORT).show()
     }
 
-    override fun showGenericError() {
+    override suspend fun showGenericError() {
         Snackbar.make(appBar, string.generic, Snackbar.LENGTH_SHORT).show()
     }
 
-    override fun showAuthenticationError() {
+    override suspend fun showAuthenticationError() {
         Snackbar.make(appBar, string.authentication, Snackbar.LENGTH_SHORT).show()
     }
 }


### PR DESCRIPTION
Love this repo!

Unless I have misunderstood, Arrow Fx uses the `suspend` modifier to indicate methods that perform a side effects. From the [docs](https://arrow-kt.io/docs/0.10/fx/):

> In Arrow Fx, we use suspend fun to denote a function that may cause side effects when invoked.

and the example:

````
suspend fun sayHello(): Unit =
    println("Hello World")

suspend fun sayGoodBye(): Unit =
    println("Good bye World!")

fun greet(): IO<Unit> =
    IO.fx {
        !effect { sayHello() }
        !effect { sayGoodBye() }
    }
````

whereas we want this to fail with a compilation error:

````
fun greet(): IO<Unit> =
    IO.fx {
        sayHello() // compilation fails because this method is not called from another suspend method 
        sayGoodBye()
    }
````

If we want the app to reflect this distinction, we will have to make our side-effectful view methods have the `suspend` modifier.

I have run the app and the tests and everything seems OK making this change
